### PR TITLE
Fix BTree for balance splitting.

### DIFF
--- a/BTreeOLC/BTreeOLC.h
+++ b/BTreeOLC/BTreeOLC.h
@@ -145,7 +145,7 @@ struct BTreeLeaf : public BTreeLeafBase {
 
    BTreeLeaf* split(Key& sep) {
       BTreeLeaf* newLeaf = new BTreeLeaf();
-      newLeaf->count = count-(count/2);
+      newLeaf->count = count/2;
       count = count-newLeaf->count;
       memcpy(newLeaf->keys, keys+count, sizeof(Key)*newLeaf->count);
       memcpy(newLeaf->payloads, payloads+count, sizeof(Payload)*newLeaf->count);
@@ -200,7 +200,7 @@ struct BTreeInner : public BTreeInnerBase {
 
    BTreeInner* split(Key& sep) {
       BTreeInner* newInner=new BTreeInner();
-      newInner->count=count-(count/2);
+      newInner->count=count/2;
       count=count-newInner->count-1;
       sep=keys[count];
       memcpy(newInner->keys,keys+count+1,sizeof(Key)*(newInner->count+1));


### PR DESCRIPTION
A balance splitting for a full node with `m` max entries is as follows:

For example the Inner Node, `m` must be even (to support preemptive splitting), thus the number of the key is `count=m-1`, while `count` is odd. The node is split into two nodes each with `floor(count/2)` node, and the center node is inserted into the parent. 

In previous implementation, the inner node is split into nodes with `count-ceil(count/2)-1` and `ceil(count/2)` keys. For example, when `m=4`, the full inner node with 3 keys is split into nodes with `3-ceil(3/2)-1 = 0` and `ceil(3/2) = 2` keys. Which is imbalance and conflict with to BTree's definition, that _"Every internal node has at least ⌈m/2⌉ children"_.